### PR TITLE
feature: DiarystateContext

### DIFF
--- a/diary/src/App.jsx
+++ b/diary/src/App.jsx
@@ -1,10 +1,12 @@
-import { useEffect, useReducer, useRef } from "react";
+import React, { useEffect, useReducer, useRef, useState } from "react";
 import { Routes, Route } from "react-router-dom";
 import './App.css';
 import Home from "./pages/Home.jsx";
 import Write from "./pages/Write.jsx";
 import Diary from "./pages/Diary.jsx";
 import Edit from "./pages/Edit.jsx";
+
+export const DiaryStateContext = React.createContext();
 
 const mockData = [
   {
@@ -51,14 +53,16 @@ function reducer(state, action) {
 function App() {
   const [data, dispatch] = useReducer(reducer, []);
   const idRef = useRef(0);
+  const [isDataLoaded, setIsDataLoaded] = useState(false);
 
   useEffect(() => {
     dispatch({
       type: "INIT",
       data: mockData,
     });
+    setIsDataLoaded(true);
   }, []);
-  
+
   const onCreate = (date, content, emotionId) => {
     dispatch({
       type: "CREATE",
@@ -90,18 +94,22 @@ function App() {
       targetId,
     });
   };
-
-  return (
-    <div className="App">
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/write" element={<Write />} />
-        <Route path="/diary/:id" element={<Diary />} />
-        <Route path="/edit" element={<Edit />} />
-      </Routes>
-
-    </div>
-  );
+  if (!isDataLoaded) {
+    return <div>데이터를 불러오는 중입니다.</div>;
+  } else {
+    return (
+      <DiaryStateContext.Provider value={data}>
+        <div className="App">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/write" element={<Write />} />
+            <Route path="/diary/:id" element={<Diary />} />
+            <Route path="/edit" element={<Edit />} />
+          </Routes>
+        </div>
+      </DiaryStateContext.Provider>
+    );
+  }
 }
 
 export default App;


### PR DESCRIPTION
- 일기 State 값을 공급하기 위한 Context 객체 DiaryStateContext를 생성.
- 이때, Context가 컴포넌트 외부에 있어야 함.
(내부에 있으면 리밴더 될 때마다 새롭게 생성되기 때문에)
- DiatyStateContext의 Prvider 컴포넌트를 App의 자식으로 배치.
- DiaryStateContext.Provider가 App 컴포넌트의 return 문 태그 내부를 감싸도록 배치 후, Props로 일기 State 값을 전달. 
→ 이제 DiaryStateContext.Provider 아래의 컴포넌트들은 props Drilling없이 useContext를 이용해 일기 State를 꺼내 쓸 수 있음.