### PR TITLE
feature: Load diary data from web storage when refreshing.

### DIFF
--- a/diary/src/App.jsx
+++ b/diary/src/App.jsx
@@ -9,26 +9,6 @@ import Edit from "./pages/Edit.jsx";
 export const DiaryStateContext = React.createContext();
 export const DiaryDispathContext = React.createContext();
 
-const mockData = [
-  {
-    id: "mock1",
-    date: new Date().getTime() - 1,
-    content: "mock1",
-    emotionId: 1,
-  },
-  {
-    id: "mock2",
-    date: new Date().getTime() - 2,
-    content: "mock2",
-    emotionId: 2,
-  },
-  {
-    id: "mock3",
-    date: new Date().getTime() - 3,
-    content: "mock3",
-    emotionId: 3,
-  },
-];
 function reducer(state, action) {
   switch (action.type) {
     case "CREATE": {
@@ -65,10 +45,24 @@ function App() {
   const [isDataLoaded, setIsDataLoaded] = useState(false);
 
   useEffect(() => {
-    dispatch({
-      type: "INIT",
-      data: mockData,
-    });
+    const rawData = localStorage.getItem("diary");
+    if (!rawData) {
+      setIsDataLoaded(true);
+      return;
+    }
+    const localData = JSON.parse(rawData);
+
+    if (localData.length === 0) {
+      // JSON.parse로 복구한 일기 데이터의 길이가 0이면, 변수 isDataLoaded를 true로 변경하고 콜백 함수 종료.
+      setIsDataLoaded(true);
+      return;
+    }
+    // 불러온 일기 데이터를 id를 기준으로 내림차순으로 정렬.
+    localData.sort((a, b) => Number(b.id) - Number(a.id));
+    idRef.current = localData[0].id + 1;
+
+    // 불러온 일기 데이터로 일기 State를 초기화.
+    dispatch({ type: "INIT", data: localData });
     setIsDataLoaded(true);
   }, []);
 

--- a/diary/src/component/Viewer.jsx
+++ b/diary/src/component/Viewer.jsx
@@ -3,7 +3,6 @@ import "./Viewer.css";
 
 const Viewer = ({ content, emotionId }) => {
     const emotionItem = emotionList.find((it) => it.id === emotionId);
-    console.log(emotionItem);
     return (
         <div className="viewer">
             <section>


### PR DESCRIPTION
- 새로고침하거나 다시 접속할 때 로컬 스토리지의 일기를 자동으로 불러오도록 만들기
- 새로운 일기를 추가할 때 id가 중복되지 않도록 만드는 기능.
- 불러온 일기 데이터로 일기 State를 초기화.
- 이제 새로고침해도 로컬 스토리지 데이터를 잘 불러옴.
- 사용자가 작성한 일기는 새로고침하거나 탭 또는 브라우저를 종료해도 사라지지 않음.